### PR TITLE
fix: package names, examples

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .@"clay-zig",
+    .name = .clay_zig,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0",
     .dependencies = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "clay-zig",
+    .name = .@"clay-zig",
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0",
     .dependencies = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,7 @@
     .name = .clay_zig,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0",
+    .fingerprint = 0xeddbd686c4b526c0,
     .dependencies = .{
         .clay_src = .{
             .url = "git+https://github.com/nicbarker/clay#c9e1a63378ecfba448ecd42796838264b10adafb",

--- a/examples/raylib-video-demo/build.zig
+++ b/examples/raylib-video-demo/build.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const cl = @import("clay-zig");
+const cl = @import("clay_zig");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) void {
     b.installArtifact(exe);
 
     { // Dependencies
-        const raylib_dep = b.dependency("raylib-zig", .{
+        const raylib_dep = b.dependency("raylib_zig", .{
             .target = target,
             .optimize = optimize,
             .shared = true,
@@ -23,7 +23,7 @@ pub fn build(b: *std.Build) void {
         exe.root_module.addImport("raylib", raylib_dep.module("raylib"));
         exe.linkLibrary(raylib_dep.artifact("raylib"));
 
-        const clay_dep = b.dependency("clay-zig", .{
+        const clay_dep = b.dependency("clay_zig", .{
             .target = target,
             .optimize = optimize,
         });

--- a/examples/raylib-video-demo/build.zig.zon
+++ b/examples/raylib-video-demo/build.zig.zon
@@ -1,12 +1,13 @@
 .{
-    .name = "raylib-video-demo",
+    .name = .raylib_video_demo,
     .version = "0.0.0",
+    .fingerprint = 0xac5e81113fe932d0,
     .dependencies = .{
-        .@"raylib-zig" = .{
+        .raylib_zig = .{
             .url = "https://github.com/Not-Nik/raylib-zig/archive/devel.tar.gz",
-            .hash = "122058d3ea6318efb819d0bffba630afd1a459fa3a99b4bfe4b680a937d5de04d2fc",
+            .hash = "raylib_zig-5.6.0-dev-KE8REBMyBQCnQ9RBhHsoSKr97XmDHF84wx3g0UiMRDxj",
         },
-        .@"clay-zig" = .{
+        .clay_zig = .{
             .path = "../../",
         },
     },

--- a/examples/raylib-video-demo/src/main.zig
+++ b/examples/raylib-video-demo/src/main.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
         .msaa_4x_hint = true,
         .vsync_hint = true,
     });
-    rl.setTraceLogLevel(.log_warning);
+    rl.setTraceLogLevel(.warning);
     rl.initWindow(1024, 768, "Introducing Clay Demo");
     defer rl.closeWindow();
 
@@ -40,7 +40,7 @@ pub fn main() !void {
     cl.setMeasureTextFunction(renderer.measureText);
 
     renderer.fonts[FONT_ID_BODY_16] = rl.cdef.LoadFontEx("resources/Roboto-Regular.ttf", 48, 0, 400);
-    rl.setTextureFilter(renderer.fonts[FONT_ID_BODY_16].?.texture, .texture_filter_bilinear);
+    rl.setTextureFilter(renderer.fonts[FONT_ID_BODY_16].?.texture, .bilinear);
 
     while (!rl.windowShouldClose()) {
         cl.setLayoutDimensions(.{
@@ -50,7 +50,7 @@ pub fn main() !void {
 
         const mousePosition = rl.getMousePosition();
         const scrollDelta = rl.getMouseWheelMoveV();
-        cl.setPointerState(mousePosition, rl.isMouseButtonDown(.mouse_button_left));
+        cl.setPointerState(mousePosition, rl.isMouseButtonDown(.left));
         cl.updateScrollContainers(true, scrollDelta, rl.getFrameTime());
 
         const content_background_config = cl.RectangleConfig{
@@ -59,7 +59,7 @@ pub fn main() !void {
         };
 
         // Toggle the inspector with spacebar
-        if (rl.isKeyPressed(.key_space)) cl.setDebugModeEnabled(!cl.isDebugModeEnabled());
+        if (rl.isKeyPressed(.space)) cl.setDebugModeEnabled(!cl.isDebugModeEnabled());
 
         cl.beginLayout();
         if (cl.open(.{


### PR DESCRIPTION
Converted the `build.zig.zon` package name to an enum as required by zig. Updated the example code to use new Raylib bindings + fixed the dependency names and references. Also added required fingerprints.